### PR TITLE
Electron 2.0 compatibility (Atom > v.1.28

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,7 +86,10 @@ module.exports = MarkdownImageAssistant =
         return if img.isEmpty()
         editor = atom.workspace.getActiveTextEditor()
         e.stopImmediatePropagation()
-        imgbuffer = img.toPNG()
+        if Number process.versions.electron[0] >= 2
+          imgbuffer = img.toPNG()
+        else 
+          imgbuffer = img.toPng()
         @process_file(editor, imgbuffer, ".png", "")
 
     # write a given buffer to the local "assets/" directory

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -86,7 +86,7 @@ module.exports = MarkdownImageAssistant =
         return if img.isEmpty()
         editor = atom.workspace.getActiveTextEditor()
         e.stopImmediatePropagation()
-        imgbuffer = img.toPng()
+        imgbuffer = img.toPNG()
         @process_file(editor, imgbuffer, ".png", "")
 
     # write a given buffer to the local "assets/" directory


### PR DESCRIPTION
Atom upgraded to Electron 2.0 in v.1.28, image.toPng method then changed to image.PNG
If you want to ensure compatibilty you could probably also do something like this:

        if Number process.versions.electron[0] >= 2
          imgbuffer = img.toPNG()
        else 
          imgbuffer = img.toPng()