### PR TITLE
Fix preserve original file names

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -110,7 +110,10 @@ module.exports = MarkdownImageAssistant =
         md5.update(imgbuffer)
 
         if !atom.config.get('markdown-image-assistant.prependTargetFileName')
-            img_filename = "#{md5.digest('hex').slice(0,8)}#{extname}"
+            if origname != ""
+              img_filename = "#{origname}#{extname}"
+            else
+              img_filename = "#{md5.digest('hex').slice(0,8)}#{extname}"
         else if origname == ""
             img_filename = "#{path.parse(target_file).name}-#{md5.digest('hex').slice(0,8)}#{extname}"
         else


### PR DESCRIPTION
The option to preserve original file names only worked if the prepend target file name option was also enabled. This change fixes that.